### PR TITLE
SHA-256d Identity

### DIFF
--- a/digital-signature/README.md
+++ b/digital-signature/README.md
@@ -13,7 +13,7 @@ not altered in transit (integrity).
 
 This example shows how to build a simple digital signature scheme on the Risc0
 platform. In this scheme, the sender possesses a passphrase which they use to
-sign messages. Their identity is simply the SHA-256 hash of their passphrase.
+sign messages. Their identity is simply the SHA-256d hash of their passphrase.
 
 In our scheme, we would send the message, the commitment (message and
 passphrase), and the receipt. The allows the recipient to know that we have the

--- a/digital-signature/methods/guest/src/bin/sign.rs
+++ b/digital-signature/methods/guest/src/bin/sign.rs
@@ -24,7 +24,7 @@ risc0_zkvm_guest::entry!(main);
 pub fn main() {
     let request: SigningRequest = env::read();
     env::commit(&SignMessageCommit {
-        identity: *sha::digest(&request.passphrase.pass),
+        identity: *sha::digest_u8_slice(&request.passphrase.pass),
         msg: request.msg,
     });
 }


### PR DESCRIPTION
The digital signature example readme states that the identity is "simply the SHA-256 hash" of the passphrase.

This is incorrect, as in the example using the passphrase `passw0rd` the identity is computed as `d8897a807edd55e86dd44101b209274b4ce103117b07ce292a75282a69944aeb`.

Meanwhile, the SHA-256 hash of `passw0rd` is `8f0e2f76e22b43e2855189877e7dc1e1e7d98c226c95db247cd1d547928334a9`.

Reading through the code, it seems the identity is hashed twice, but as a 'serialized' object in the second hash.

This PR changes the readme to mention the identity as the SHA-256**d** hash of the passphrase, and updates [sign.rs](https://github.com/risc0/risc0-rust-examples/blob/fd37a90b250555f18c46727792a4e116ea87f934/digital-signature/methods/guest/src/bin/sign.rs#L27) to use `sha::digest_u8_slice` rather than `sha::digest`, which fixes the discrepancy.
