### PR TITLE
Add factors example

### DIFF
--- a/factors/.gitignore
+++ b/factors/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+Cargo.lock
+methods/guest/Cargo.lock
+target/

--- a/factors/Cargo.toml
+++ b/factors/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+members = [
+    "methods",
+    "factors",
+]

--- a/factors/README.md
+++ b/factors/README.md
@@ -8,7 +8,10 @@ Choosing a simple example necessarily excludes all of the more complex use cases
 
 ## Run this example
 
-To run, simply use the command
+First, make sure [rustup](https://rustup.rs) is installed. This project uses a [nightly](https://doc.rust-lang.org/book/appendix-07-nightly-rust.html) version of [Rust](https://doc.rust-lang.org/book/ch01-01-installation.html). The [`rust-toolchain`](rust-toolchain) file will be used by `cargo` to automatically install the correct version.
+
+To build all methods and execute the method within the zkVM, run the following command:
+
 ```
 cargo run
 ```

--- a/factors/README.md
+++ b/factors/README.md
@@ -1,0 +1,7 @@
+# Factors
+
+The _factors_ example is a minimalistic RISC Zero zkVM proof. The prover demonstrates that they know two nontrivial factors (i.e. both greater than 1) of a number, without revealing what those factors are. Thus, the prover demonstrates that a number is composite -- and that they know the factors -- without revealing any further information about the number.
+
+This example was chosen because it is very straightforward. Implementing the verified multiplication and reporting the result in the receipt involves no complexity beyond what is necessary to run the zkVM at all. We therefore hope this example is a good place to look to see all the steps necessary to use the RISC Zero zkVM without any superfluous problem-specific details.
+
+Choosing a simple example necessarily excludes all of the more complex use cases -- so if you are looking for anything beyond the basics, we recommend looking at other examples in this repository!

--- a/factors/README.md
+++ b/factors/README.md
@@ -5,3 +5,10 @@ The _factors_ example is a minimalistic RISC Zero zkVM proof. The prover demonst
 This example was chosen because it is very straightforward. Implementing the verified multiplication and reporting the result in the receipt involves no complexity beyond what is necessary to run the zkVM at all. We therefore hope this example is a good place to look to see all the steps necessary to use the RISC Zero zkVM without any superfluous problem-specific details.
 
 Choosing a simple example necessarily excludes all of the more complex use cases -- so if you are looking for anything beyond the basics, we recommend looking at other examples in this repository!
+
+## Run this example
+
+To run, simply use the command
+```
+cargo run
+```

--- a/factors/factors/Cargo.toml
+++ b/factors/factors/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "starter"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+methods = { path = "../methods" }
+risc0-zkvm = "0.11"
+serde = "1.0"

--- a/factors/factors/src/main.rs
+++ b/factors/factors/src/main.rs
@@ -1,0 +1,29 @@
+use methods::{MULTIPLY_ID, MULTIPLY_PATH};
+use risc0_zkvm::host::Prover;
+use risc0_zkvm::serde::{from_slice, to_vec};
+
+fn main() {
+    // Pick two numbers
+    let a: u64 = 17;
+    let b: u64 = 23;
+
+    // Multiply them inside the ZKP
+    // First, we make the prover, loading the 'multiply' method
+    let mut prover = Prover::new(&std::fs::read(MULTIPLY_PATH).unwrap(), MULTIPLY_ID).unwrap();
+    // Next we send a & b to the guest
+    prover.add_input(to_vec(&a).unwrap().as_slice()).unwrap();
+    prover.add_input(to_vec(&b).unwrap().as_slice()).unwrap();
+    // Run prover & generate receipt
+    let receipt = prover.run().unwrap();
+
+    // Extract journal of receipt (i.e. output c, where c = a * b)
+    let c: u64 = from_slice(&receipt.get_journal_vec().unwrap()).unwrap();
+
+    // Print an assertion
+    println!("I know the factors of {}, and I can prove it!", c);
+
+    // Here is where one would send 'receipt' over the network...
+
+    // Verify receipt, panic if it's wrong
+    receipt.verify(MULTIPLY_ID).unwrap();
+}

--- a/factors/factors/src/main.rs
+++ b/factors/factors/src/main.rs
@@ -9,15 +9,21 @@ fn main() {
 
     // Multiply them inside the ZKP
     // First, we make the prover, loading the 'multiply' method
-    let mut prover = Prover::new(&std::fs::read(MULTIPLY_PATH).unwrap(), MULTIPLY_ID).unwrap();
+    let multiply_src = std::fs::read(MULTIPLY_PATH)
+        .expect("Method code should be present at the specified path; did you use the correct *_PATH constant?");
+    let mut prover = Prover::new(&multiply_src, MULTIPLY_ID)
+        .expect("Prover should be constructed from valid method source code and corresponding method ID");
+
     // Next we send a & b to the guest
     prover.add_input(to_vec(&a).unwrap().as_slice()).unwrap();
     prover.add_input(to_vec(&b).unwrap().as_slice()).unwrap();
     // Run prover & generate receipt
-    let receipt = prover.run().unwrap();
+    let receipt = prover.run()
+        .expect("Valid code should be provable if it doesn't overflow the cycle limit. See `embed_methods_with_options` for information on adjusting maximum cycle count.");
 
     // Extract journal of receipt (i.e. output c, where c = a * b)
-    let c: u64 = from_slice(&receipt.get_journal_vec().unwrap()).unwrap();
+    let c: u64 = from_slice(&receipt.get_journal_vec().expect("Journal should be available for valid receipts"))
+        .expect("Journal output should deserialize into the same types (& order) that it was written");
 
     // Print an assertion
     println!("I know the factors of {}, and I can prove it!", c);
@@ -25,5 +31,6 @@ fn main() {
     // Here is where one would send 'receipt' over the network...
 
     // Verify receipt, panic if it's wrong
-    receipt.verify(MULTIPLY_ID).unwrap();
+    receipt.verify(MULTIPLY_ID)
+        .expect("Code you have proven should successfully verify; did you specify the correct method ID?");
 }

--- a/factors/factors/src/main.rs
+++ b/factors/factors/src/main.rs
@@ -11,8 +11,9 @@ fn main() {
     // First, we make the prover, loading the 'multiply' method
     let multiply_src = std::fs::read(MULTIPLY_PATH)
         .expect("Method code should be present at the specified path; did you use the correct *_PATH constant?");
-    let mut prover = Prover::new(&multiply_src, MULTIPLY_ID)
-        .expect("Prover should be constructed from valid method source code and corresponding method ID");
+    let mut prover = Prover::new(&multiply_src, MULTIPLY_ID).expect(
+        "Prover should be constructed from valid method source code and corresponding method ID",
+    );
 
     // Next we send a & b to the guest
     prover.add_input(to_vec(&a).unwrap().as_slice()).unwrap();
@@ -22,8 +23,12 @@ fn main() {
         .expect("Valid code should be provable if it doesn't overflow the cycle limit. See `embed_methods_with_options` for information on adjusting maximum cycle count.");
 
     // Extract journal of receipt (i.e. output c, where c = a * b)
-    let c: u64 = from_slice(&receipt.get_journal_vec().expect("Journal should be available for valid receipts"))
-        .expect("Journal output should deserialize into the same types (& order) that it was written");
+    let c: u64 = from_slice(
+        &receipt
+            .get_journal_vec()
+            .expect("Journal should be available for valid receipts"),
+    )
+    .expect("Journal output should deserialize into the same types (& order) that it was written");
 
     // Print an assertion
     println!("I know the factors of {}, and I can prove it!", c);
@@ -31,6 +36,7 @@ fn main() {
     // Here is where one would send 'receipt' over the network...
 
     // Verify receipt, panic if it's wrong
-    receipt.verify(MULTIPLY_ID)
-        .expect("Code you have proven should successfully verify; did you specify the correct method ID?");
+    receipt.verify(MULTIPLY_ID).expect(
+        "Code you have proven should successfully verify; did you specify the correct method ID?",
+    );
 }

--- a/factors/methods/Cargo.toml
+++ b/factors/methods/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "methods"
+version = "0.1.0"
+edition = "2021"
+
+[build-dependencies]
+risc0-build = "0.11"
+
+[package.metadata.risc0]
+methods = ["guest"]

--- a/factors/methods/build.rs
+++ b/factors/methods/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    risc0_build::embed_methods();
+}

--- a/factors/methods/guest/Cargo.toml
+++ b/factors/methods/guest/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "methods-guest"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+
+[build-dependencies]
+risc0-build = "0.11"
+
+[dependencies]
+risc0-zkvm-guest = "0.11"

--- a/factors/methods/guest/build.rs
+++ b/factors/methods/guest/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    risc0_build::link();
+}

--- a/factors/methods/guest/src/bin/multiply.rs
+++ b/factors/methods/guest/src/bin/multiply.rs
@@ -1,0 +1,20 @@
+#![no_main]
+#![no_std]
+
+use risc0_zkvm_guest::env;
+
+risc0_zkvm_guest::entry!(main);
+
+pub fn main() {
+    // Load the first number from the host
+    let a: u64 = env::read();
+    // Load the second number from the host
+    let b: u64 = env::read();
+    // Verify that neither of them are 1 (i.e. nontrivial factors)
+    if a == 1 || b == 1 {
+        panic!("Trivial factors")
+    }
+    // Compute the product while being careful with integer overflow
+    let product = a.checked_mul(b).expect("Integer overflow");
+    env::commit(&product);
+}

--- a/factors/methods/src/lib.rs
+++ b/factors/methods/src/lib.rs
@@ -1,0 +1,1 @@
+include!(concat!(env!("OUT_DIR"), "/methods.rs"));

--- a/factors/rust-toolchain
+++ b/factors/rust-toolchain
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "nightly-2022-06-20"
+components = [ "rustfmt", "rust-src" ]
+targets = [ "wasm32-unknown-unknown" ]
+profile = "minimal"


### PR DESCRIPTION
This moves the current example from https://github.com/risc0/risc0-rust-starter into this repository as the `factors` example. It multiplies two nontrivial (non-one) factors and reports the result. This allows a prover to demonstrate that they know two factors of a composite number without revealing the factors.

This is intended to land in conjunction with https://github.com/risc0/risc0-rust-starter/pull/20 -- then the current example from the starter repo will live here (as the `factors` example), and the starter repo will be a blank template with information about what code needs to be added to make a full project.