### PR TITLE
Add length checks to Wordle

### DIFF
--- a/wordle/core/src/lib.rs
+++ b/wordle/core/src/lib.rs
@@ -1,6 +1,8 @@
 use risc0_zkp::core::sha::Digest;
 use serde::{Deserialize, Serialize};
 
+pub const WORD_LENGTH: usize = 5;
+
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub enum LetterFeedback {
     LetterCorrect,
@@ -9,7 +11,7 @@ pub enum LetterFeedback {
     LetterMiss,
 }
 
-pub type WordFeedback = [LetterFeedback; 5];
+pub type WordFeedback = [LetterFeedback; WORD_LENGTH];
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct GameState {

--- a/wordle/methods/guest/src/bin/wordle.rs
+++ b/wordle/methods/guest/src/bin/wordle.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use risc0_zkvm_guest::{env, sha};
-use wordle_core::{WordFeedback, LetterFeedback, GameState};
+use wordle_core::{WORD_LENGTH, WordFeedback, LetterFeedback, GameState};
 
 risc0_zkvm_guest::entry!(main);
 
@@ -9,11 +9,19 @@ pub fn main() {
     let word: String = env::read();
     let guess: String = env::read();
 
+    if word.chars().count() != WORD_LENGTH {
+        panic!("secret word must have length 5!")
+    }
+
+    if guess.chars().count() != WORD_LENGTH {
+        panic!("guess must have length 5!")
+    }
+
     let correct_word_hash = sha::digest_u8_slice(&word.as_bytes()).to_owned();
     env::commit(&correct_word_hash);
 
     let mut score: WordFeedback = WordFeedback::default();
-    for i in 0..5 {
+    for i in 0..WORD_LENGTH {
         score[i] = if word.as_bytes()[i] == guess.as_bytes()[i] {
             LetterFeedback::LetterCorrect
         } else if word.as_bytes().contains(&guess.as_bytes()[i]) {


### PR DESCRIPTION
Paul noticed that the guest would panic with an unhelpful error message if the user enters too short of a guess. I've made two changes here: if the guest checks a guess or secret word with a length other than 5, it panics with a clearer message; the client will also validate the length of the guess before submitting it, so this should never happen in practice.