### PR TITLE
Remove addition of sha/rust-toolchain in #40

### DIFF
--- a/sha/rust-toolchain.toml
+++ b/sha/rust-toolchain.toml
@@ -1,4 +1,0 @@
-[toolchain]
-channel = "nightly-2022-10-28"
-components = [ "rustfmt", "rust-src" ]
-profile = "minimal"


### PR DESCRIPTION
PR #40 accidentally added `sha/rust-toolchain.toml`. This PR removes it.
