### PR TITLE
Ensure coverage for copyright and license information

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,20 @@ on:
 
 jobs:
   check:
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - chess
+          - digital-signature
+          - factors
+          - json
+          - password-checker
+          - sha
+          - voting-machine
+          - wordle
+          - waldo
+        os: [Linux, macOS]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -26,7 +40,9 @@ jobs:
           crate: cargo-sort
           version: "1.0"
       - run: cargo fmt --all -- --check
+        working-directory: ${{ matrix.project }}
       - run: cargo sort --workspace --check
+        working-directory: ${{ matrix.project }}
       - run: npx @kt3k/license-checker
 
   test:
@@ -50,7 +66,5 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - run: cargo fmt --all -- --check
-        working-directory: ${{ matrix.project }} 
       - run: cargo test --release
         working-directory: ${{ matrix.project }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,25 @@ on:
   workflow_dispatch:
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Fetch the merge commit and origin/HEAD.
+          fetch-depth: 2
+      - uses: risc0/actions-rs-toolchain@v1
+        with:
+          toolchain: stable
+      - name: Install cargo-sort
+        uses: risc0/cargo-install@v1
+        with:
+          crate: cargo-sort
+          version: "1.0"
+      - run: cargo fmt --all -- --check
+      - run: cargo sort --workspace --check
+      - run: npx @kt3k/license-checker
+
   test:
     strategy:
       fail-fast: false
@@ -23,6 +42,7 @@ jobs:
           - sha
           - voting-machine
           - wordle
+          - waldo
         os: [Linux, macOS]
     runs-on: [self-hosted, "${{ matrix.os }}"]
     steps:

--- a/.licenserc.json
+++ b/.licenserc.json
@@ -1,0 +1,21 @@
+{
+  "**/*.{cpp,h,rs}": [
+    "// Copyright 2023 RISC Zero, Inc.",
+    "//",
+    "// Licensed under the Apache License, Version 2.0 (the \"License\");",
+    "// you may not use this file except in compliance with the License.",
+    "// You may obtain a copy of the License at",
+    "//",
+    "//     http://www.apache.org/licenses/LICENSE-2.0",
+    "//",
+    "// Unless required by applicable law or agreed to in writing, software",
+    "// distributed under the License is distributed on an \"AS IS\" BASIS,",
+    "// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
+    "// See the License for the specific language governing permissions and",
+    "// limitations under the License."
+  ],
+  "ignore": [
+    "target/",
+    "tmp/"
+  ]
+}

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+nodejs lts

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/chess/Cargo.toml
+++ b/chess/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
 members = [
-    "methods",
     "host",
+    "methods",
 ]

--- a/chess/core/src/lib.rs
+++ b/chess/core/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/chess/host/Cargo.toml
+++ b/chess/host/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+chess-core = { path = "../core" }
 clap = "4.0"
-shakmaty = "0.22"
 methods = { path = "../methods" }
 risc0-zkvm = "0.11"
 serde = "1.0"
-chess-core = { path = "../core" }
+shakmaty = "0.22"

--- a/chess/host/src/main.rs
+++ b/chess/host/src/main.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use chess_core::Inputs;
 use clap::{Arg, Command};
 use methods::{CHECKMATE_ID, CHECKMATE_PATH};

--- a/chess/methods/build.rs
+++ b/chess/methods/build.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 fn main() {
     risc0_build::embed_methods();
 }

--- a/chess/methods/guest/build.rs
+++ b/chess/methods/guest/build.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 fn main() {
     risc0_build::link();
 }

--- a/chess/methods/guest/src/bin/checkmate.rs
+++ b/chess/methods/guest/src/bin/checkmate.rs
@@ -1,8 +1,24 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![no_main]
 
-use shakmaty::{Chess, Position, fen::Fen, Setup, CastlingMode, FromSetup, Move, san::San};
 use chess_core::Inputs;
 use risc0_zkvm_guest::env;
+use shakmaty::fen::Fen;
+use shakmaty::san::San;
+use shakmaty::{CastlingMode, Chess, FromSetup, Move, Position, Setup};
 
 risc0_zkvm_guest::entry!(main);
 

--- a/chess/methods/src/lib.rs
+++ b/chess/methods/src/lib.rs
@@ -1,1 +1,15 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 include!(concat!(env!("OUT_DIR"), "/methods.rs"));

--- a/digital-signature/Cargo.toml
+++ b/digital-signature/Cargo.toml
@@ -1,8 +1,8 @@
 [workspace]
 members = [
+  "cli",
   "core",
   "methods",
-  "cli",
 ]
 
 default-members = ["cli"]

--- a/digital-signature/cli/Cargo.toml
+++ b/digital-signature/cli/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 
 [dependencies]
 clap = "3.1.18"
+digital-signature-core = { path = "../core" }
+digital-signature-methods = { path = "../methods" }
 env_logger = "0.9.0"
 log = "0.4.17"
-digital-signature-methods = { path = "../methods" }
-digital-signature-core = { path = "../core" }
-risc0-zkvm = "0.11"
 risc0-zkp = "0.11"
+risc0-zkvm = "0.11"
 serde = "1.0"
 sha2 = "0.10.2"
 

--- a/digital-signature/cli/src/lib.rs
+++ b/digital-signature/cli/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Risc0, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/digital-signature/cli/src/main.rs
+++ b/digital-signature/cli/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Risc0, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/digital-signature/core/src/lib.rs
+++ b/digital-signature/core/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Risc0, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/digital-signature/methods/build.rs
+++ b/digital-signature/methods/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Risc0, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/digital-signature/methods/guest/build.rs
+++ b/digital-signature/methods/guest/build.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 fn main() {
     risc0_build::link();
 }

--- a/digital-signature/methods/guest/src/bin/sign.rs
+++ b/digital-signature/methods/guest/src/bin/sign.rs
@@ -15,9 +15,8 @@
 #![no_main]
 #![no_std]
 
-use risc0_zkvm_guest::{env, sha};
-
 use digital_signature_core::{SignMessageCommit, SigningRequest};
+use risc0_zkvm_guest::{env, sha};
 
 risc0_zkvm_guest::entry!(main);
 

--- a/digital-signature/methods/guest/src/bin/sign.rs
+++ b/digital-signature/methods/guest/src/bin/sign.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Risc0, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/digital-signature/methods/src/lib.rs
+++ b/digital-signature/methods/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Risc0, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/factors/Cargo.toml
+++ b/factors/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
 members = [
-    "methods",
     "factors",
+    "methods",
 ]

--- a/factors/factors/src/main.rs
+++ b/factors/factors/src/main.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use methods::{MULTIPLY_ID, MULTIPLY_PATH};
 use risc0_zkvm::host::Prover;
 use risc0_zkvm::serde::{from_slice, to_vec};

--- a/factors/methods/build.rs
+++ b/factors/methods/build.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 fn main() {
     risc0_build::embed_methods();
 }

--- a/factors/methods/guest/build.rs
+++ b/factors/methods/guest/build.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 fn main() {
     risc0_build::link();
 }

--- a/factors/methods/guest/src/bin/multiply.rs
+++ b/factors/methods/guest/src/bin/multiply.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![no_main]
 #![no_std]
 

--- a/factors/methods/src/lib.rs
+++ b/factors/methods/src/lib.rs
@@ -1,1 +1,15 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 include!(concat!(env!("OUT_DIR"), "/methods.rs"));

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
 members = [
-    "methods",
     "host",
+    "methods",
 ]

--- a/json/core/src/lib.rs
+++ b/json/core/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use risc0_zkp::core::sha::Digest;
 use serde::{Deserialize, Serialize};
 

--- a/json/host/Cargo.toml
+++ b/json/host/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+json = "0.12"
 json-core = { path = "../core" }
 methods = { path = "../methods" }
-json = "0.12"
 risc0-zkp = "0.11"
 risc0-zkvm = "0.11"
 serde = "1.0"

--- a/json/host/src/main.rs
+++ b/json/host/src/main.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::io::prelude::*;
 
 use json_core::Outputs;

--- a/json/methods/build.rs
+++ b/json/methods/build.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 fn main() {
     risc0_build::embed_methods();
 }

--- a/json/methods/guest/build.rs
+++ b/json/methods/guest/build.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 fn main() {
     risc0_build::link();
 }

--- a/json/methods/guest/src/bin/search_json.rs
+++ b/json/methods/guest/src/bin/search_json.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![no_main]
 
 use json::parse;

--- a/json/methods/src/lib.rs
+++ b/json/methods/src/lib.rs
@@ -1,1 +1,15 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 include!(concat!(env!("OUT_DIR"), "/methods.rs"));

--- a/password-checker/Cargo.toml
+++ b/password-checker/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
 members = [
-  "methods",
   "cli"
-]
+,
+  "methods"]

--- a/password-checker/cli/src/main.rs
+++ b/password-checker/cli/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Risc0, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/password-checker/core/src/lib.rs
+++ b/password-checker/core/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Risc0, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/password-checker/methods/build.rs
+++ b/password-checker/methods/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Risc0, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/password-checker/methods/guest/build.rs
+++ b/password-checker/methods/guest/build.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 fn main() {
     risc0_build::link();
 }

--- a/password-checker/methods/guest/src/bin/pw_checker.rs
+++ b/password-checker/methods/guest/src/bin/pw_checker.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Risc0, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/password-checker/methods/src/lib.rs
+++ b/password-checker/methods/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Risc0, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sha/Cargo.toml
+++ b/sha/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
 members = [
-    "methods",
     "host",
+    "methods",
 ]

--- a/sha/host/Cargo.toml
+++ b/sha/host/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-methods = { path = "../methods" }
 clap = "4.0"
+methods = { path = "../methods" }
 risc0-zkp = "0.11"
 risc0-zkvm = "0.11"
 serde = "1.0"

--- a/sha/host/src/main.rs
+++ b/sha/host/src/main.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use clap::{Arg, Command};
 use methods::{HASH_ID, HASH_PATH};
 use risc0_zkp::core::sha::Digest;

--- a/sha/methods/build.rs
+++ b/sha/methods/build.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 fn main() {
     risc0_build::embed_methods();
 }

--- a/sha/methods/guest/build.rs
+++ b/sha/methods/guest/build.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 fn main() {
     risc0_build::link();
 }

--- a/sha/methods/guest/src/bin/hash.rs
+++ b/sha/methods/guest/src/bin/hash.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![no_main]
 
 use risc0_zkvm_guest::{env, sha};

--- a/sha/methods/src/lib.rs
+++ b/sha/methods/src/lib.rs
@@ -1,1 +1,15 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 include!(concat!(env!("OUT_DIR"), "/methods.rs"));

--- a/voting-machine/Cargo.toml
+++ b/voting-machine/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [
   "core",
-  "methods",
   "host",
+  "methods",
 ]

--- a/voting-machine/core/src/lib.rs
+++ b/voting-machine/core/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Risc0, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/voting-machine/host/Cargo.toml
+++ b/voting-machine/host/Cargo.toml
@@ -9,5 +9,5 @@ ctor = "0.1"
 env_logger = "0.9.0"
 log = "0.4.17"
 risc0-zkvm = "0.11"
-voting-machine-methods = { path = "../methods" }
 voting-machine-core = { path = "../core" }
+voting-machine-methods = { path = "../methods" }

--- a/voting-machine/host/src/lib.rs
+++ b/voting-machine/host/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Risc0, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/voting-machine/methods/build.rs
+++ b/voting-machine/methods/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Risc0, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/voting-machine/methods/guest/build.rs
+++ b/voting-machine/methods/guest/build.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Risc0, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/voting-machine/methods/guest/src/bin/freeze.rs
+++ b/voting-machine/methods/guest/src/bin/freeze.rs
@@ -16,7 +16,6 @@
 #![no_std]
 
 use risc0_zkvm_guest::{env, sha};
-
 use voting_machine_core::{FreezeVotingMachineCommit, FreezeVotingMachineParams};
 
 risc0_zkvm_guest::entry!(main);

--- a/voting-machine/methods/guest/src/bin/freeze.rs
+++ b/voting-machine/methods/guest/src/bin/freeze.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Risc0, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/voting-machine/methods/guest/src/bin/init.rs
+++ b/voting-machine/methods/guest/src/bin/init.rs
@@ -16,7 +16,6 @@
 #![no_std]
 
 use risc0_zkvm_guest::{env, sha};
-
 use voting_machine_core::{InitializeVotingMachineCommit, VotingMachineState};
 
 risc0_zkvm_guest::entry!(main);
@@ -29,4 +28,3 @@ pub fn main() {
         state: *sha::digest(&state),
     });
 }
-

--- a/voting-machine/methods/guest/src/bin/init.rs
+++ b/voting-machine/methods/guest/src/bin/init.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Risc0, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/voting-machine/methods/guest/src/bin/submit.rs
+++ b/voting-machine/methods/guest/src/bin/submit.rs
@@ -16,7 +16,6 @@
 #![no_std]
 
 use risc0_zkvm_guest::{env, sha};
-
 use voting_machine_core::{SubmitBallotCommit, SubmitBallotParams};
 
 risc0_zkvm_guest::entry!(main);

--- a/voting-machine/methods/guest/src/bin/submit.rs
+++ b/voting-machine/methods/guest/src/bin/submit.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Risc0, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/voting-machine/methods/src/lib.rs
+++ b/voting-machine/methods/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Risc0, Inc.
+// Copyright 2023 RISC Zero, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/waldo/Cargo.toml
+++ b/waldo/Cargo.toml
@@ -1,8 +1,8 @@
 [workspace]
 members = [
-    "methods",
     "core",
     "host",
+    "methods",
 ]
 
 [profile.release]
@@ -10,6 +10,6 @@ opt-level = 3
 
 [patch.crates-io]
 # TODO(victor): Remove these patch definitions when d02f606a is included in a release.
-risc0-zkp = { git = "https://github.com/risc0/risc0", rev = "d02f606ab7d59ad45dc75314eb3e0eef5c9a26b7"}
-risc0-zkvm = { git = "https://github.com/risc0/risc0", rev = "d02f606ab7d59ad45dc75314eb3e0eef5c9a26b7"}
-risc0-build = { git = "https://github.com/risc0/risc0", rev = "d02f606ab7d59ad45dc75314eb3e0eef5c9a26b7"}
+risc0-zkp = { git = "https://github.com/risc0/risc0", rev = "d02f606ab7d59ad45dc75314eb3e0eef5c9a26b7" }
+risc0-zkvm = { git = "https://github.com/risc0/risc0", rev = "d02f606ab7d59ad45dc75314eb3e0eef5c9a26b7" }
+risc0-build = { git = "https://github.com/risc0/risc0", rev = "d02f606ab7d59ad45dc75314eb3e0eef5c9a26b7" }

--- a/waldo/core/Cargo.toml
+++ b/waldo/core/Cargo.toml
@@ -2,7 +2,6 @@
 name = "waldo-core"
 version = "0.1.0"
 edition = "2021"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/waldo/core/src/image.rs
+++ b/waldo/core/src/image.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use image::{DynamicImage, GrayImage, Rgb, RgbImage};
 use serde::{Deserialize, Serialize};
 

--- a/waldo/core/src/lib.rs
+++ b/waldo/core/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #[macro_use]
 extern crate merkle_light_derive;
 extern crate merkle_light;

--- a/waldo/core/src/merkle.rs
+++ b/waldo/core/src/merkle.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::cmp::Ordering;
 use std::hash::Hasher;
 use std::marker::PhantomData;

--- a/waldo/host/Cargo.toml
+++ b/waldo/host/Cargo.toml
@@ -10,7 +10,7 @@ image = "0.24.5"
 risc0-zkp = "1.0.0-rc.2"
 # TODO: Determine what where the issue is when using metal and reenable that feature here.
 # risc0-zkvm = { version = "1.0.0-rc.2", default-features = false, features = ["std", "prove", "metal"] }
-risc0-zkvm = { version = "1.0.0-rc.2", default-features = false, features = ["std", "prove", "metal"] }
+risc0-zkvm = { version = "1.0.0-rc.2", default-features = false, features = ["std", "prove"] }
 serde = "1.0"
 viuer = "0.6"
 waldo-core = { path = "../core" }

--- a/waldo/host/Cargo.toml
+++ b/waldo/host/Cargo.toml
@@ -10,7 +10,7 @@ image = "0.24.5"
 risc0-zkp = "1.0.0-rc.2"
 # TODO: Determine what where the issue is when using metal and reenable that feature here.
 # risc0-zkvm = { version = "1.0.0-rc.2", default-features = false, features = ["std", "prove", "metal"] }
-risc0-zkvm = { version = "1.0.0-rc.2", default-features = false, features = ["std", "prove"] }
+risc0-zkvm = { version = "1.0.0-rc.2", default-features = false, features = ["std", "prove", "metal"] }
 serde = "1.0"
 viuer = "0.6"
 waldo-core = { path = "../core" }

--- a/waldo/host/src/bin/prove.rs
+++ b/waldo/host/src/bin/prove.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::error::Error;
 use std::fs;
 use std::path::PathBuf;

--- a/waldo/host/src/bin/verify.rs
+++ b/waldo/host/src/bin/verify.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::error::Error;
 use std::fs;
 use std::path::PathBuf;

--- a/waldo/methods/build.rs
+++ b/waldo/methods/build.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::collections::hash_map::HashMap;
 
 use risc0_build::GuestOptions;

--- a/waldo/methods/guest/src/bin/image_crop.rs
+++ b/waldo/methods/guest/src/bin/image_crop.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![no_main]
 // #![no_std]
 

--- a/waldo/methods/src/lib.rs
+++ b/waldo/methods/src/lib.rs
@@ -1,1 +1,15 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 include!(concat!(env!("OUT_DIR"), "/methods.rs"));

--- a/wordle/core/src/lib.rs
+++ b/wordle/core/src/lib.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use risc0_zkp::core::sha::Digest;
 use serde::{Deserialize, Serialize};
 

--- a/wordle/host/Cargo.toml
+++ b/wordle/host/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 methods = { path = "../methods" }
-risc0-zkvm = "0.11"
-risc0-zkp = "0.11"
-wordle-core = { path = "../core" }
-serde = "1.0"
 rand = "0.8.5"
+risc0-zkp = "0.11"
+risc0-zkvm = "0.11"
+serde = "1.0"
+wordle-core = { path = "../core" }

--- a/wordle/host/src/main.rs
+++ b/wordle/host/src/main.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::io;
 
 use methods::{WORDLE_ID, WORDLE_PATH};

--- a/wordle/host/src/wordlist.rs
+++ b/wordle/host/src/wordlist.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pub mod words {
 
     use rand::seq::SliceRandom;

--- a/wordle/methods/build.rs
+++ b/wordle/methods/build.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 fn main() {
     risc0_build::embed_methods();
 }

--- a/wordle/methods/guest/build.rs
+++ b/wordle/methods/guest/build.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 fn main() {
     risc0_build::link();
 }

--- a/wordle/methods/guest/src/bin/wordle.rs
+++ b/wordle/methods/guest/src/bin/wordle.rs
@@ -1,7 +1,21 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![no_main]
 
 use risc0_zkvm_guest::{env, sha};
-use wordle_core::{WORD_LENGTH, WordFeedback, LetterFeedback, GameState};
+use wordle_core::{GameState, LetterFeedback, WordFeedback, WORD_LENGTH};
 
 risc0_zkvm_guest::entry!(main);
 
@@ -30,6 +44,9 @@ pub fn main() {
             LetterFeedback::LetterMiss
         }
     }
-    let game_state = GameState { correct_word_hash: correct_word_hash, feedback: score };
+    let game_state = GameState {
+        correct_word_hash: correct_word_hash,
+        feedback: score,
+    };
     env::commit(&game_state);
 }

--- a/wordle/methods/src/lib.rs
+++ b/wordle/methods/src/lib.rs
@@ -1,1 +1,15 @@
+// Copyright 2023 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 include!(concat!(env!("OUT_DIR"), "/methods.rs"));


### PR DESCRIPTION
Prompted by @flaub in https://github.com/risc0/risc0-rust-examples/pull/40#discussion_r1067755525,
this PR ensures that all files contain a copyright and license header, and additionally adds a copy
of the Apache-2.0 license to the repository.
