### PR TITLE
Fix SHA-256 example by using different hashing method

### DIFF
--- a/sha/Cargo.lock
+++ b/sha/Cargo.lock
@@ -591,6 +591,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,10 +1503,12 @@ name = "sha-example"
 version = "0.12.0"
 dependencies = [
  "clap",
+ "hex",
  "methods",
  "risc0-zkp",
  "risc0-zkvm",
  "serde",
+ "sha2",
 ]
 
 [[package]]

--- a/sha/Cargo.lock
+++ b/sha/Cargo.lock
@@ -1508,7 +1508,6 @@ dependencies = [
  "risc0-zkp",
  "risc0-zkvm",
  "serde",
- "sha2",
 ]
 
 [[package]]

--- a/sha/host/Cargo.toml
+++ b/sha/host/Cargo.toml
@@ -9,3 +9,7 @@ methods = { path = "../methods" }
 risc0-zkp = { git = "https://github.com/risc0/risc0.git", rev = "65fb3871e3ef468be0a306d9f1adf5631d943b46" }
 risc0-zkvm = { git = "https://github.com/risc0/risc0.git", rev = "65fb3871e3ef468be0a306d9f1adf5631d943b46" }
 serde = "1.0"
+
+[dev-dependencies]
+sha2 = "0.10"
+hex = "0.4"

--- a/sha/host/Cargo.toml
+++ b/sha/host/Cargo.toml
@@ -11,5 +11,4 @@ risc0-zkvm = { git = "https://github.com/risc0/risc0.git", rev = "65fb3871e3ef46
 serde = "1.0"
 
 [dev-dependencies]
-sha2 = "0.10"
 hex = "0.4"

--- a/sha/host/src/main.rs
+++ b/sha/host/src/main.rs
@@ -51,29 +51,25 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use methods::{HASH_ID, HASH_PATH};
+    use methods::HASH_ID;
     use risc0_zkp::core::sha::Digest;
-    use risc0_zkvm::host::Prover;
-    use risc0_zkvm::serde::{from_slice, to_vec};
+    use risc0_zkvm::serde::from_slice;
+    use sha2::{Digest as _, Sha256};
 
     use crate::provably_hash;
 
+    const TEST_STRING: &str = "abcd";
+
     #[test]
     fn main() {
-        let receipt = provably_hash("abc");
+        let receipt = provably_hash(TEST_STRING);
         receipt.verify(HASH_ID).expect("Proven code should verify");
 
-        let vec = receipt
-            .get_journal_vec()
-            .expect("Journal should be accessible");
-        let digest =
-            from_slice::<Digest>(vec.as_slice()).expect("Journal should contain SHA Digest");
+        let digest = from_slice::<Digest>(receipt.journal.as_slice())
+            .expect("Journal should contain SHA Digest");
         assert_eq!(
-            digest,
-            Digest::new([
-                0xba7816bf, 0x8f01cfea, 0x414140de, 0x5dae2223, 0xb00361a3, 0x96177a9c, 0xb410ff61,
-                0xf20015ad
-            ]),
+            hex::encode(digest.as_bytes()),
+            hex::encode(Sha256::digest(TEST_STRING).as_slice()),
             "We expect to match the reference SHA-256 hash of the standard test value 'abc'"
         );
     }

--- a/sha/host/src/main.rs
+++ b/sha/host/src/main.rs
@@ -58,7 +58,7 @@ mod tests {
 
     use crate::provably_hash;
 
-    const TEST_STRING: &str = "abcd";
+    const TEST_STRING: &str = "abc";
 
     #[test]
     fn main() {

--- a/sha/host/src/main.rs
+++ b/sha/host/src/main.rs
@@ -54,7 +54,6 @@ mod tests {
     use methods::HASH_ID;
     use risc0_zkp::core::sha::Digest;
     use risc0_zkvm::serde::from_slice;
-    use sha2::{Digest as _, Sha256};
 
     use crate::provably_hash;
 
@@ -69,7 +68,7 @@ mod tests {
             .expect("Journal should contain SHA Digest");
         assert_eq!(
             hex::encode(digest.as_bytes()),
-            hex::encode(Sha256::digest(TEST_STRING).as_slice()),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
             "We expect to match the reference SHA-256 hash of the standard test value 'abc'"
         );
     }

--- a/sha/methods/guest/src/bin/hash.rs
+++ b/sha/methods/guest/src/bin/hash.rs
@@ -14,12 +14,13 @@
 
 #![no_main]
 
-use risc0_zkvm::guest::{env, sha};
+use risc0_zkvm::guest::env;
+use risc0_zkvm::sha::{sha, Sha};
 
 risc0_zkvm::guest::entry!(main);
 
 pub fn main() {
     let data: String = env::read();
-    let sha = sha::digest(&data.as_bytes());
-    env::commit(&sha);
+    let sha = sha().hash_bytes(&data.as_bytes());
+    env::commit(&*sha);
 }


### PR DESCRIPTION
It appears that the `risc0_zkvm::guest::sha::digest` method is currently broken. This PR works
around this issue and fixes some other references in the SHA-256 example to get the test to pass.
