### PR TITLE
Use Elf contents instead of loading files

### DIFF
--- a/chess/host/src/main.rs
+++ b/chess/host/src/main.rs
@@ -14,7 +14,7 @@
 
 use chess_core::Inputs;
 use clap::{Arg, Command};
-use methods::{CHECKMATE_ID, CHECKMATE_PATH};
+use methods::{CHECKMATE_ELF, CHECKMATE_ID};
 use risc0_zkvm::serde::{from_slice, to_vec};
 use risc0_zkvm::Prover;
 use shakmaty::fen::Fen;
@@ -42,8 +42,7 @@ fn main() {
     };
 
     // Make the prover.
-    let method_code = std::fs::read(CHECKMATE_PATH).unwrap();
-    let mut prover = Prover::new(&method_code, CHECKMATE_ID).unwrap();
+    let mut prover = Prover::new(CHECKMATE_ELF, CHECKMATE_ID).unwrap();
 
     prover.add_input_u32_slice(&to_vec(&inputs).expect("Should be serializable"));
 

--- a/digital-signature/cli/src/lib.rs
+++ b/digital-signature/cli/src/lib.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 pub use digital_signature_core::{Message, Passphrase, SignMessageCommit, SigningRequest};
-use digital_signature_methods::{SIGN_ID, SIGN_PATH};
+use digital_signature_methods::{SIGN_ELF, SIGN_ID};
 use risc0_zkvm::serde::{from_slice, to_vec};
 use risc0_zkvm::{Prover, Receipt, Result};
 use sha2::{Digest, Sha256};
@@ -63,7 +63,7 @@ pub fn sign(pass_str: impl AsRef<[u8]>, msg_str: impl AsRef<[u8]>) -> Result<Sig
         msg: msg,
     };
 
-    let mut prover = Prover::new(&std::fs::read(SIGN_PATH).unwrap(), SIGN_ID)?;
+    let mut prover = Prover::new(SIGN_ELF, SIGN_ID)?;
     let vec = to_vec(&params).unwrap();
     prover.add_input_u32_slice(vec.as_slice());
     let receipt = prover.run()?;

--- a/factors/factors/src/main.rs
+++ b/factors/factors/src/main.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use methods::{MULTIPLY_ID, MULTIPLY_PATH};
+use methods::{MULTIPLY_ELF, MULTIPLY_ID};
 use risc0_zkvm::serde::{from_slice, to_vec};
 use risc0_zkvm::Prover;
 
@@ -23,9 +23,7 @@ fn main() {
 
     // Multiply them inside the ZKP
     // First, we make the prover, loading the 'multiply' method
-    let multiply_src = std::fs::read(MULTIPLY_PATH)
-        .expect("Method code should be present at the specified path; did you use the correct *_PATH constant?");
-    let mut prover = Prover::new(&multiply_src, MULTIPLY_ID).expect(
+    let mut prover = Prover::new(MULTIPLY_ELF, MULTIPLY_ID).expect(
         "Prover should be constructed from valid method source code and corresponding method ID",
     );
 

--- a/json/host/src/main.rs
+++ b/json/host/src/main.rs
@@ -15,7 +15,7 @@
 use std::io::prelude::*;
 
 use json_core::Outputs;
-use methods::{SEARCH_JSON_ID, SEARCH_JSON_PATH};
+use methods::{SEARCH_JSON_ELF, SEARCH_JSON_ID};
 use risc0_zkvm::serde::{from_slice, to_vec};
 use risc0_zkvm::Prover;
 
@@ -27,8 +27,7 @@ fn main() {
         .expect("Should not have I/O errors");
 
     // Make the prover.
-    let method_code = std::fs::read(SEARCH_JSON_PATH).expect("Method code should be at path");
-    let mut prover = Prover::new(&method_code, SEARCH_JSON_ID)
+    let mut prover = Prover::new(SEARCH_JSON_ELF, SEARCH_JSON_ID)
         .expect("Prover should be constructed from matching method code & ID");
 
     prover.add_input_u32_slice(&to_vec(&data).expect("should be serializable"));

--- a/password-checker/cli/src/main.rs
+++ b/password-checker/cli/src/main.rs
@@ -15,7 +15,7 @@
 use std::fs;
 
 use password_checker_core::PasswordRequest;
-use password_checker_methods::{PW_CHECKER_ID, PW_CHECKER_PATH};
+use password_checker_methods::{PW_CHECKER_ELF, PW_CHECKER_ID};
 use rand::prelude::*;
 use risc0_zkp::core::sha::Digest;
 use risc0_zkvm::serde::{from_slice, to_vec};
@@ -32,8 +32,7 @@ fn main() {
     };
 
     // a new prover is created to run the pw_checker method
-    let elf_contents = fs::read(PW_CHECKER_PATH).unwrap();
-    let mut prover = Prover::new(&elf_contents, PW_CHECKER_ID).unwrap();
+    let mut prover = Prover::new(PW_CHECKER_ELF, PW_CHECKER_ID).unwrap();
 
     // Adding input to the prover makes it readable by the guest
     let vec = to_vec(&request).unwrap();

--- a/sha/host/src/main.rs
+++ b/sha/host/src/main.rs
@@ -13,16 +13,14 @@
 // limitations under the License.
 
 use clap::{Arg, Command};
-use methods::{HASH_ID, HASH_PATH};
+use methods::{HASH_ELF, HASH_ID};
 use risc0_zkp::core::sha::Digest;
 use risc0_zkvm::serde::{from_slice, to_vec};
 use risc0_zkvm::{Prover, Receipt};
 
 fn provably_hash(input: &str) -> Receipt {
     // Make the prover.
-    let method_code =
-        std::fs::read(HASH_PATH).expect("Method code should be present at the specified path");
-    let mut prover = Prover::new(&method_code, HASH_ID)
+    let mut prover = Prover::new(HASH_ELF, HASH_ID)
         .expect("Prover should be constructed from matching code and method ID");
 
     prover.add_input_u32_slice(&to_vec(input).expect("input string should serialize"));

--- a/voting-machine/host/src/lib.rs
+++ b/voting-machine/host/src/lib.rs
@@ -19,7 +19,7 @@ use voting_machine_core::{
     InitializeVotingMachineCommit, SubmitBallotCommit, SubmitBallotParams, SubmitBallotResult,
     VotingMachineState,
 };
-use voting_machine_methods::{FREEZE_ID, FREEZE_PATH, INIT_ID, INIT_PATH, SUBMIT_ID, SUBMIT_PATH};
+use voting_machine_methods::{FREEZE_ELF, FREEZE_ID, INIT_ELF, INIT_ID, SUBMIT_ELF, SUBMIT_ID};
 
 pub struct InitMessage {
     receipt: Receipt,
@@ -78,7 +78,7 @@ impl PollingStation {
 
     pub fn init(&self) -> Result<InitMessage> {
         log::info!("init");
-        let mut prover = Prover::new(&std::fs::read(INIT_PATH).unwrap(), INIT_ID)?;
+        let mut prover = Prover::new(INIT_ELF, INIT_ID)?;
         let vec = to_vec(&self.state).unwrap();
         prover.add_input_u32_slice(vec.as_slice());
         let receipt = prover.run()?;
@@ -88,7 +88,7 @@ impl PollingStation {
     pub fn submit(&mut self, ballot: &Ballot) -> Result<SubmitBallotMessage> {
         log::info!("submit: {:?}", ballot);
         let params = SubmitBallotParams::new(self.state.clone(), ballot.clone());
-        let mut prover = Prover::new(&std::fs::read(SUBMIT_PATH).unwrap(), SUBMIT_ID)?;
+        let mut prover = Prover::new(SUBMIT_ELF, SUBMIT_ID)?;
         let vec = to_vec(&params).unwrap();
         prover.add_input_u32_slice(vec.as_slice());
         let receipt = prover.run()?;
@@ -103,7 +103,7 @@ impl PollingStation {
     pub fn freeze(&mut self) -> Result<FreezeStationMessage> {
         log::info!("freeze");
         let params = FreezeVotingMachineParams::new(self.state.clone());
-        let mut prover = Prover::new(&std::fs::read(FREEZE_PATH).unwrap(), FREEZE_ID)?;
+        let mut prover = Prover::new(FREEZE_ELF, FREEZE_ID)?;
         let vec = to_vec(&params).unwrap();
         prover.add_input_u32_slice(vec.as_slice());
         let receipt = prover.run()?;

--- a/waldo/host/src/bin/prove.rs
+++ b/waldo/host/src/bin/prove.rs
@@ -24,7 +24,7 @@ use risc0_zkvm::serde;
 use waldo_core::image::{ImageMask, ImageMerkleTree, IMAGE_CHUNK_SIZE};
 use waldo_core::merkle::VECTOR_ORACLE_CHANNEL;
 use waldo_core::PrivateInput;
-use waldo_methods::{IMAGE_CROP_ID, IMAGE_CROP_PATH};
+use waldo_methods::{IMAGE_CROP_ELF, IMAGE_CROP_ID};
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
@@ -102,12 +102,11 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Make the prover, loading the image crop method binary and method ID, and registering a
     // send_recv callback to communicate vector oracle data from the Merkle tree.
-    let method_code = std::fs::read(IMAGE_CROP_PATH)?;
     let prover_opts = ProverOpts::default().with_sendrecv_callback(
         VECTOR_ORACLE_CHANNEL,
         img_merkle_tree.vector_oracle_callback(),
     );
-    let mut prover = Prover::new_with_opts(&method_code, IMAGE_CROP_ID, prover_opts)?;
+    let mut prover = Prover::new_with_opts(IMAGE_CROP_ELF, IMAGE_CROP_ID, prover_opts)?;
 
     // Give the private input to the guest, including Waldo's location.
     let input = PrivateInput {

--- a/wordle/host/src/main.rs
+++ b/wordle/host/src/main.rs
@@ -14,7 +14,7 @@
 
 use std::io;
 
-use methods::{WORDLE_ID, WORDLE_PATH};
+use methods::{WORDLE_ELF, WORDLE_ID};
 use risc0_zkvm::serde::to_vec;
 use risc0_zkvm::{Prover, Receipt};
 use wordle_core::WORD_LENGTH;
@@ -44,8 +44,7 @@ impl Server<'_> {
     }
 
     pub fn check_round(&self, guess_word: &str) -> Receipt {
-        let method_code = std::fs::read(WORDLE_PATH).expect("failed to load method code");
-        let mut prover = Prover::new(&method_code, WORDLE_ID).expect("failed to construct prover");
+        let mut prover = Prover::new(WORDLE_ELF, WORDLE_ID).expect("failed to construct prover");
 
         prover.add_input_u32_slice(to_vec(self.secret_word).unwrap().as_slice());
         prover.add_input_u32_slice(to_vec(&guess_word).unwrap().as_slice());


### PR DESCRIPTION
With 0.12, we can now directly build the prover from the Elf contents rather than needing to load a file. I.e., use *_ELF instead of *_PATH.