### PR TITLE
Add concurrency to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,10 @@ on:
 
   # Allows running this workflow manually from the Actions tab
   workflow_dispatch:
+  
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check:


### PR DESCRIPTION
This PR adds concurrency to the Github workflows to automatically cancel current in-progress workflow runs when new commits are added.

The definition `${{ github.workflow }}` makes it so that only this workflow is cancelled instead of a widespread cancelling of workflows.

The definition group: `${{ github.event.pull_request.number || github.ref }}` targets workflows within the same PR, branch, or tag.